### PR TITLE
Add Laravel-style Hola Mundo placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # test2
+
+Este repositorio contiene un ejemplo minimalista de proyecto estilo Laravel que muestra "Hola Mundo". Consulte la carpeta `laravel_holamundo` para ver el ejemplo.

--- a/laravel_holamundo/README.md
+++ b/laravel_holamundo/README.md
@@ -1,0 +1,15 @@
+# Laravel Hola Mundo (Placeholder)
+
+Este proyecto es un ejemplo minimalista de un proyecto "Laravel" que simplemente imprime "Hola Mundo". **No** es un proyecto Laravel completo ya que el entorno no cuenta con Composer para instalar las dependencias. Sin embargo, podrá ejecutar un servidor PHP simple para mostrar el texto.
+
+## Estructura
+- `public/index.php`: punto de entrada que imprime "Hola Mundo" si accede a la ruta `/`.
+
+## Uso
+Ejecute un servidor PHP desde el directorio `public`:
+
+```bash
+php -S localhost:8000 -t public
+```
+
+Luego abra `http://localhost:8000/` en su navegador y deberá ver `Hola Mundo`.

--- a/laravel_holamundo/public/index.php
+++ b/laravel_holamundo/public/index.php
@@ -1,0 +1,13 @@
+<?php
+// Placeholder front controller for the Hola Mundo project
+// This does not include the full Laravel framework.
+
+// Simulate a simple router
+if ($_SERVER['REQUEST_URI'] === '/' || $_SERVER['REQUEST_URI'] === '') {
+    echo "Hola Mundo";
+    return;
+}
+
+http_response_code(404);
+echo "Ruta no encontrada";
+


### PR DESCRIPTION
## Summary
- add a minimal Laravel-style project under `laravel_holamundo`
- show how to run a simple PHP server to display "Hola Mundo"
- update the repo README to mention the example project

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eb21d7634832f9d7b23cc267e9d9a